### PR TITLE
NodeGraph: Fix configuring arc colors with mixed case field names

### DIFF
--- a/public/app/plugins/panel/nodeGraph/utils.test.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.test.ts
@@ -170,7 +170,7 @@ describe('processNodes', () => {
           { name: 'mainStat', type: FieldType.string },
           { name: 'secondaryStat', type: FieldType.string },
           { name: 'arc__primary', type: FieldType.string },
-          { name: 'arc__secondary', type: FieldType.string },
+          { name: 'arc__Secondary', type: FieldType.string },
           { name: 'arc__tertiary', type: FieldType.string },
         ],
       }),
@@ -192,7 +192,7 @@ describe('processNodes', () => {
         secondaryStatUnit: 'ms/r',
         arcs: [
           { field: 'arc__primary', color: 'red' },
-          { field: 'arc__secondary', color: 'yellow' },
+          { field: 'arc__Secondary', color: 'yellow' },
           { field: 'arc__tertiary', color: '#dd40ec' },
         ],
       },
@@ -212,7 +212,7 @@ describe('processNodes', () => {
     expect(nodesFrame?.fields.find((f) => f.name === 'arc__primary')?.config).toEqual({
       color: { mode: 'fixed', fixedColor: 'red' },
     });
-    expect(nodesFrame?.fields.find((f) => f.name === 'arc__secondary')?.config).toEqual({
+    expect(nodesFrame?.fields.find((f) => f.name === 'arc__Secondary')?.config).toEqual({
       color: { mode: 'fixed', fixedColor: 'yellow' },
     });
     expect(nodesFrame?.fields.find((f) => f.name === 'arc__tertiary')?.config).toEqual({

--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -588,7 +588,7 @@ export const applyOptionsToFrames = (frames: DataFrame[], options: NodeGraphOpti
       }
       if (options?.nodes?.arcs?.length) {
         for (const arc of options.nodes.arcs) {
-          const field = frame.fields.find((field) => field.name.toLowerCase() === arc.field);
+          const field = frame.fields.find((field) => field.name === arc.field);
           if (field && arc.color) {
             field.config = { ...field.config, color: { fixedColor: arc.color, mode: FieldColorModeId.Fixed } };
           }


### PR DESCRIPTION
Fixes mixed case field names used to create colored arcs in NodeGraph's nodes.

**Which issue(s) does this PR fix?**:

When a field has mixed case in the data frame, and the user uses the options panel to set a color for it, the code that applies the color property to the field in the DataFrame accidentally skips the field.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
